### PR TITLE
Fixed header typos (`Managment` → `Management`)

### DIFF
--- a/addtask.html
+++ b/addtask.html
@@ -36,7 +36,7 @@
 
         <header>
             <h1>Add Task</h1>
-            <h5>Learning Managment System Project</h5>
+            <h5>Learning Management System Project</h5>
         </header>
 
         <div id="content-container" class="center">

--- a/backlog.html
+++ b/backlog.html
@@ -27,7 +27,7 @@
     <!--Backlog Main Container-->
     <div id="main-container" class="Column">
         <h1>Backlog</h1>
-        <h5>Learning Managment System Project</h5>
+        <h5>Learning Management System Project</h5>
 
         <!--Legend-->
         <div w3-include-html="./templates/legendBox.html"></div>

--- a/help.html
+++ b/help.html
@@ -21,7 +21,7 @@
     <article class="helpArticle">
         <section class="helpHeader">
             <h1>Help</h1>
-            <h5>Learning Managment System Project</h5>
+            <h5>Learning Management System Project</h5>
         </section>
         <section class="tab box">
             <section class="helpButtons">


### PR DESCRIPTION
Good evening,
when visiting join I noticed a small typo in the header so that `Management` became `Managment` several times. But it should be fixed now. :)
Have a happy new year! ✨